### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -16,7 +16,7 @@ begin	KEYWORD2
 end	KEYWORD2
 thresoldsWrite	KEYWORD2
 temperatureWrite	KEYWORD2
-hysteresis KEYWORD2
+hysteresis	KEYWORD2
 rpmCount	KEYWORD2
 rpmRead	KEYWORD2
 rpmTop	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords